### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-branches:
-  only:
-    - master
 language: ruby
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ rvm:
   - 1.9.3
   - ruby-head
   - jruby-19mode # JRuby in 1.9 mode
-  - rbx-2.2
+  - rbx

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 require "bundler/gem_tasks"
 
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec


### PR DESCRIPTION
- RSpec needs to be added to the Rakefile for travis builds
- Bundler needs to be upgraded to support the development dependency
- Using latest Rubinius version—there is a [known issue](https://github.com/bundler/bundler/issues/3269) where `bundle install --jobs` fails in 2.2

https://travis-ci.org/adamstegman/ruby-hl7-zps/builds/75328594
